### PR TITLE
feat: 通知機能（Notification API）の完全実装

### DIFF
--- a/src/components/TaskCard.tsx
+++ b/src/components/TaskCard.tsx
@@ -15,6 +15,7 @@ export function TaskCard({ task, onToggle, onClick }: TaskCardProps) {
   
   return (
     <Card 
+      id={`task-${task.id}`}
       className={cn(
         'cursor-pointer transition-all hover:shadow-md',
         task.status === 'done' && 'opacity-60'

--- a/src/hooks/useNotifications.test.ts
+++ b/src/hooks/useNotifications.test.ts
@@ -1,0 +1,169 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+import { useNotifications } from './useNotifications';
+import { useServiceWorker } from './useServiceWorker';
+
+// Mock dependencies
+vi.mock('./useServiceWorker');
+
+vi.mock('../store/useSettings', () => ({
+  useSettings: () => ({
+    notifyBeforeMin: 15,
+    snoozeMin: 5,
+  }),
+}));
+
+describe('useNotifications', () => {
+  const mockNotification = {
+    permission: 'default' as NotificationPermission,
+    requestPermission: vi.fn(() => Promise.resolve('granted' as NotificationPermission)),
+  };
+
+  beforeEach(() => {
+    // Mock Notification API
+    Object.defineProperty(global, 'Notification', {
+      writable: true,
+      value: mockNotification,
+    });
+    
+    // Mock navigator.serviceWorker
+    Object.defineProperty(navigator, 'serviceWorker', {
+      writable: true,
+      value: {
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+      },
+    });
+    
+    // Default mock for useServiceWorker
+    vi.mocked(useServiceWorker).mockReturnValue({
+      registration: null,
+      isOffline: false,
+      needRefresh: false,
+      offlineReady: false,
+      reloadPage: vi.fn(),
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should initialize with current notification permission', () => {
+    const { result } = renderHook(() => useNotifications());
+    expect(result.current.permission).toBe('default');
+  });
+
+  it('should request permission when asked', async () => {
+    const { result } = renderHook(() => useNotifications());
+    
+    await act(async () => {
+      const permission = await result.current.requestPermission();
+      expect(permission).toBe('granted');
+    });
+    
+    expect(mockNotification.requestPermission).toHaveBeenCalled();
+  });
+
+  it('should schedule notification for task with due date', () => {
+    // Set permission to granted before creating the hook
+    mockNotification.permission = 'granted';
+    
+    const mockPostMessage = vi.fn();
+    const mockServiceWorker = {
+      active: {
+        postMessage: mockPostMessage,
+      } as any,
+    } as ServiceWorkerRegistration;
+    
+    vi.mocked(useServiceWorker).mockReturnValue({
+      registration: mockServiceWorker,
+      isOffline: false,
+      needRefresh: false,
+      offlineReady: false,
+      reloadPage: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useNotifications());
+    
+    const mockTask = {
+      id: 'test-task',
+      title: 'Test Task',
+      dueAt: Date.now() + 30 * 60 * 1000, // 30 minutes from now
+      status: 'pending' as const,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    result.current.scheduleNotification(mockTask);
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: 'SCHEDULE_NOTIFICATION',
+      payload: {
+        taskId: mockTask.id,
+        title: mockTask.title,
+        dueAt: mockTask.dueAt - (15 * 60 * 1000), // 15 minutes before due
+      },
+    });
+  });
+
+  it('should cancel notification for task', () => {
+    const mockPostMessage = vi.fn();
+    vi.mocked(useServiceWorker).mockReturnValue({
+      registration: {
+        active: {
+          postMessage: mockPostMessage,
+        } as any,
+      } as ServiceWorkerRegistration,
+      isOffline: false,
+      needRefresh: false,
+      offlineReady: false,
+      reloadPage: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useNotifications());
+    
+    result.current.cancelNotification('test-task');
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: 'CANCEL_NOTIFICATION',
+      taskId: 'test-task',
+    });
+  });
+
+  it('should snooze notification for task', () => {
+    const mockPostMessage = vi.fn();
+    vi.mocked(useServiceWorker).mockReturnValue({
+      registration: {
+        active: {
+          postMessage: mockPostMessage,
+        } as any,
+      } as ServiceWorkerRegistration,
+      isOffline: false,
+      needRefresh: false,
+      offlineReady: false,
+      reloadPage: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useNotifications());
+    const mockTask = {
+      id: 'test-task',
+      title: 'Test Task',
+      dueAt: Date.now() + 30 * 60 * 1000,
+      status: 'pending' as const,
+      createdAt: Date.now(),
+      updatedAt: Date.now(),
+    };
+
+    result.current.snoozeNotification(mockTask);
+
+    expect(mockPostMessage).toHaveBeenCalledWith({
+      type: 'SCHEDULE_NOTIFICATION',
+      payload: {
+        taskId: mockTask.id,
+        title: mockTask.title,
+        dueAt: expect.any(Number), // Now + 5 minutes
+      },
+    });
+  });
+});

--- a/src/hooks/useNotifications.ts
+++ b/src/hooks/useNotifications.ts
@@ -53,14 +53,22 @@ export function useNotifications() {
     });
   };
 
-  const snoozeNotification = (taskId: string) => {
-    if (!registration?.active) {
+  const snoozeNotification = (task: Task) => {
+    if (!registration?.active || !task.dueAt) {
       return;
     }
 
-    // This would need to be implemented to reschedule the notification
-    // For now, we'll let the main app handle the snooze logic
-    console.log(`Snoozing task ${taskId} for ${snoozeMin} minutes`);
+    // Reschedule notification for snoozeMin minutes from now
+    const snoozeTime = Date.now() + (snoozeMin * 60 * 1000);
+    
+    registration.active.postMessage({
+      type: 'SCHEDULE_NOTIFICATION',
+      payload: {
+        taskId: task.id,
+        title: task.title,
+        dueAt: snoozeTime,
+      },
+    });
   };
 
   // Listen for messages from service worker
@@ -76,6 +84,9 @@ export function useNotifications() {
       } else if (type === 'SNOOZE_TASK') {
         // This will be handled by the main app
         window.dispatchEvent(new CustomEvent('snoozeTask', { detail: { taskId } }));
+      } else if (type === 'FOCUS_TASK') {
+        // This will be handled by the main app
+        window.dispatchEvent(new CustomEvent('focusTask', { detail: { taskId } }));
       }
     };
 

--- a/src/test/mocks/pwa-register.ts
+++ b/src/test/mocks/pwa-register.ts
@@ -1,0 +1,7 @@
+import { vi } from 'vitest';
+
+export const useRegisterSW = vi.fn(() => ({
+  offlineReady: [false, vi.fn()],
+  needRefresh: [false, vi.fn()],
+  updateServiceWorker: vi.fn(),
+}));

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
+import path from 'path';
 
 export default defineConfig({
   plugins: [react()],
@@ -7,5 +8,11 @@ export default defineConfig({
     globals: true,
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
+  },
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, './src'),
+      'virtual:pwa-register/react': path.resolve(__dirname, './src/test/mocks/pwa-register.ts'),
+    },
   },
 });


### PR DESCRIPTION
## 概要
Issue #7の実装: タスクのリマインダー通知機能を実装しました

## 変更内容
- スヌーズ機能の完全実装（5分後に再通知）
- 通知クリック時のアプリ復帰処理とタスクフォーカス機能
- 通知権限UIの改善：
  - ブロック時の警告表示
  - 権限許可時に通知設定されるタスク数の表示
- Service Worker側の改善：
  - 時間差に応じた通知テキスト（「あと◯分」「期限です」「◯分過ぎています」）
  - 通知クリック後のウィンドウ制御
- TaskCardにid属性を追加して通知からのフォーカスを可能に
- useNotificationsフックの包括的なテストスイートを追加

## テスト手順
1. アプリを開いて通知権限を許可
2. 期日付きのタスクを作成
3. 期日の15分前に通知が届くことを確認
4. 通知の「5分後に再通知」ボタンでスヌーズを確認
5. 通知をクリックしてアプリが開き、対象タスクが強調表示されることを確認
6. 通知の「完了」ボタンでタスクが完了することを確認

## 関連Issue
Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)