### PR TITLE
feat: データのエクスポート/インポート機能を実装

### DIFF
--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const alertVariants = cva(
+  "relative w-full rounded-lg border p-4 [&>svg~*]:pl-7 [&>svg+div]:translate-y-[-3px] [&>svg]:absolute [&>svg]:left-4 [&>svg]:top-4 [&>svg]:text-foreground",
+  {
+    variants: {
+      variant: {
+        default: "bg-background text-foreground",
+        destructive:
+          "border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+const Alert = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement> & VariantProps<typeof alertVariants>
+>(({ className, variant, ...props }, ref) => (
+  <div
+    ref={ref}
+    role="alert"
+    className={cn(alertVariants({ variant }), className)}
+    {...props}
+  />
+))
+Alert.displayName = "Alert"
+
+const AlertTitle = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLHeadingElement>
+>(({ className, ...props }, ref) => (
+  <h5
+    ref={ref}
+    className={cn("mb-1 font-medium leading-none tracking-tight", className)}
+    {...props}
+  />
+))
+AlertTitle.displayName = "AlertTitle"
+
+const AlertDescription = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    className={cn("text-sm [&_p]:leading-relaxed", className)}
+    {...props}
+  />
+))
+AlertDescription.displayName = "AlertDescription"
+
+export { Alert, AlertTitle, AlertDescription }

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { SettingsPage } from './SettingsPage';
+import { useSettings } from '@/store/useSettings';
+import { useTasks } from '@/store/useTasks';
+import { useCategories } from '@/store/useCategories';
+import * as exportImport from '@/utils/export-import';
+
+// Mock dependencies
+vi.mock('@/store/useSettings');
+vi.mock('@/store/useTasks');
+vi.mock('@/store/useCategories');
+vi.mock('@/utils/export-import');
+
+const mockUseSettings = {
+  settings: { snoozeDuration: 10 },
+  updateSetting: vi.fn(),
+};
+
+const mockUseTasks = {
+  load: vi.fn(),
+};
+
+const mockUseCategories = {
+  load: vi.fn(),
+};
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(component, { wrapper: BrowserRouter });
+};
+
+describe('SettingsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useSettings).mockReturnValue(mockUseSettings);
+    vi.mocked(useTasks).mockReturnValue(mockUseTasks as any);
+    vi.mocked(useCategories).mockReturnValue(mockUseCategories as any);
+  });
+
+  it('should render settings page with sections', () => {
+    renderWithRouter(<SettingsPage />);
+    
+    expect(screen.getByText('設定')).toBeInTheDocument();
+    expect(screen.getByText('通知設定')).toBeInTheDocument();
+    expect(screen.getByText('データ管理')).toBeInTheDocument();
+  });
+
+  it('should display and update snooze duration', () => {
+    renderWithRouter(<SettingsPage />);
+    
+    const input = screen.getByLabelText('スヌーズ時間（分）');
+    expect(input).toHaveValue(10);
+    
+    fireEvent.change(input, { target: { value: '15' } });
+    
+    expect(mockUseSettings.updateSetting).toHaveBeenCalledWith('snoozeDuration', 15);
+  });
+
+  it('should handle export', async () => {
+    const mockExportData = {
+      version: '1.0.0',
+      exportedAt: Date.now(),
+      data: { tasks: [], categories: [], settings: [] },
+    };
+    
+    vi.mocked(exportImport.exportData).mockResolvedValue(mockExportData);
+    vi.mocked(exportImport.downloadJSON).mockImplementation(() => {});
+    
+    renderWithRouter(<SettingsPage />);
+    
+    const exportButton = screen.getByText('データをエクスポート');
+    fireEvent.click(exportButton);
+    
+    await waitFor(() => {
+      expect(exportImport.exportData).toHaveBeenCalled();
+      expect(exportImport.downloadJSON).toHaveBeenCalledWith(mockExportData);
+    });
+  });
+
+  it('should handle file selection and show import dialog', () => {
+    renderWithRouter(<SettingsPage />);
+    
+    const importButton = screen.getByText('データをインポート');
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    
+    expect(fileInput).toBeInTheDocument();
+    expect(fileInput).toHaveClass('hidden');
+    
+    // ファイル選択をシミュレート
+    const file = new File(['{"test": "data"}'], 'test.json', { type: 'application/json' });
+    Object.defineProperty(fileInput, 'files', {
+      value: [file],
+      writable: false,
+    });
+    
+    fireEvent.change(fileInput);
+    
+    // ダイアログが表示される
+    expect(screen.getByText('データのインポート')).toBeInTheDocument();
+    expect(screen.getByText('置き換え（既存のデータを全て削除して入れ替え）')).toBeInTheDocument();
+    expect(screen.getByText('マージ（既存のデータに追加）')).toBeInTheDocument();
+  });
+
+  it('should handle import with replace mode', async () => {
+    renderWithRouter(<SettingsPage />);
+    
+    // ファイル選択をシミュレート
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{"test": "data"}'], 'test.json', { type: 'application/json' });
+    
+    vi.mocked(exportImport.readFile).mockResolvedValue('{"test": "data"}');
+    vi.mocked(exportImport.importData).mockResolvedValue();
+    
+    Object.defineProperty(fileInput, 'files', {
+      value: [file],
+      writable: false,
+    });
+    
+    fireEvent.change(fileInput);
+    
+    // インポート実行
+    const importButton = screen.getByText('インポート実行');
+    fireEvent.click(importButton);
+    
+    await waitFor(() => {
+      expect(exportImport.readFile).toHaveBeenCalledWith(file);
+      expect(exportImport.importData).toHaveBeenCalledWith({ test: "data" }, 'replace');
+      expect(mockUseTasks.load).toHaveBeenCalled();
+      expect(mockUseCategories.load).toHaveBeenCalled();
+    });
+  });
+
+  it('should handle import error', async () => {
+    renderWithRouter(<SettingsPage />);
+    
+    // ファイル選択をシミュレート
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['invalid json'], 'test.json', { type: 'application/json' });
+    
+    vi.mocked(exportImport.readFile).mockResolvedValue('invalid json');
+    
+    Object.defineProperty(fileInput, 'files', {
+      value: [file],
+      writable: false,
+    });
+    
+    fireEvent.change(fileInput);
+    
+    // インポート実行
+    const importButton = screen.getByText('インポート実行');
+    fireEvent.click(importButton);
+    
+    await waitFor(() => {
+      const errorAlert = screen.getByRole('alert');
+      expect(errorAlert).toBeInTheDocument();
+      expect(errorAlert).toHaveTextContent('Unexpected token');
+    });
+  });
+
+  it('should allow changing import mode', async () => {
+    renderWithRouter(<SettingsPage />);
+    
+    // ファイル選択をシミュレート
+    const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
+    const file = new File(['{"test": "data"}'], 'test.json', { type: 'application/json' });
+    
+    Object.defineProperty(fileInput, 'files', {
+      value: [file],
+      writable: false,
+    });
+    
+    fireEvent.change(fileInput);
+    
+    // マージモードに変更
+    const mergeRadio = screen.getByLabelText('マージ（既存のデータに追加）');
+    fireEvent.click(mergeRadio);
+    
+    vi.mocked(exportImport.readFile).mockResolvedValue('{"test": "data"}');
+    vi.mocked(exportImport.importData).mockResolvedValue();
+    
+    // インポート実行
+    const importButton = screen.getByText('インポート実行');
+    fireEvent.click(importButton);
+    
+    await waitFor(() => {
+      expect(exportImport.importData).toHaveBeenCalledWith({ test: "data" }, 'merge');
+    });
+  });
+});

--- a/src/pages/SettingsPage.tsx
+++ b/src/pages/SettingsPage.tsx
@@ -1,0 +1,221 @@
+import { useState, useRef } from 'react';
+import { Download, Upload, Save, AlertCircle } from 'lucide-react';
+import { Navbar } from '@/components/Navbar';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Label } from '@/components/ui/label';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useSettings } from '@/store/useSettings';
+import { exportData, downloadJSON, readFile, importData } from '@/utils/export-import';
+import { useTasks } from '@/store/useTasks';
+import { useCategories } from '@/store/useCategories';
+
+export function SettingsPage() {
+  const { settings, updateSetting } = useSettings();
+  const { load: loadTasks } = useTasks();
+  const { load: loadCategories } = useCategories();
+  
+  const [importMode, setImportMode] = useState<'replace' | 'merge'>('replace');
+  const [importDialogOpen, setImportDialogOpen] = useState(false);
+  const [selectedFile, setSelectedFile] = useState<File | null>(null);
+  const [importing, setImporting] = useState(false);
+  const [importError, setImportError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  
+  // エクスポート処理
+  const handleExport = async () => {
+    try {
+      const data = await exportData();
+      downloadJSON(data);
+    } catch (error) {
+      console.error('エクスポートエラー:', error);
+    }
+  };
+  
+  // ファイル選択処理
+  const handleFileSelect = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (file) {
+      setSelectedFile(file);
+      setImportDialogOpen(true);
+      setImportError(null);
+    }
+  };
+  
+  // インポート処理
+  const handleImport = async () => {
+    if (!selectedFile) return;
+    
+    setImporting(true);
+    setImportError(null);
+    
+    try {
+      const content = await readFile(selectedFile);
+      const data = JSON.parse(content);
+      
+      await importData(data, importMode);
+      
+      // データを再読み込み
+      await loadTasks();
+      await loadCategories();
+      
+      setImportDialogOpen(false);
+      setSelectedFile(null);
+      
+      // ファイル入力をリセット
+      if (fileInputRef.current) {
+        fileInputRef.current.value = '';
+      }
+    } catch (error) {
+      setImportError(error instanceof Error ? error.message : 'インポートに失敗しました');
+    } finally {
+      setImporting(false);
+    }
+  };
+  
+  return (
+    <div className="h-screen flex flex-col bg-background">
+      <Navbar />
+      
+      <div className="flex-1 overflow-y-auto">
+        <div className="container max-w-4xl mx-auto p-4">
+          <h1 className="text-2xl font-bold mb-6">設定</h1>
+          
+          {/* 通知設定 */}
+          <Card className="mb-6">
+            <CardHeader>
+              <CardTitle>通知設定</CardTitle>
+              <CardDescription>タスクのリマインダー通知に関する設定</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div className="flex items-center justify-between">
+                <Label htmlFor="snooze-duration">スヌーズ時間（分）</Label>
+                <Input
+                  id="snooze-duration"
+                  type="number"
+                  value={settings.snoozeDuration || 10}
+                  onChange={(e) => updateSetting('snoozeDuration', parseInt(e.target.value))}
+                  className="w-24"
+                  min="1"
+                  max="60"
+                />
+              </div>
+            </CardContent>
+          </Card>
+          
+          {/* データ管理 */}
+          <Card>
+            <CardHeader>
+              <CardTitle>データ管理</CardTitle>
+              <CardDescription>タスクとカテゴリーのバックアップ・復元</CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <h3 className="font-medium mb-2">エクスポート</h3>
+                <p className="text-sm text-muted-foreground mb-3">
+                  全てのタスク、カテゴリー、設定をJSONファイルとしてダウンロードします
+                </p>
+                <Button onClick={handleExport}>
+                  <Download className="h-4 w-4 mr-2" />
+                  データをエクスポート
+                </Button>
+              </div>
+              
+              <div>
+                <h3 className="font-medium mb-2">インポート</h3>
+                <p className="text-sm text-muted-foreground mb-3">
+                  JSONファイルからデータを読み込んで復元します
+                </p>
+                <Button variant="outline" onClick={() => fileInputRef.current?.click()}>
+                  <Upload className="h-4 w-4 mr-2" />
+                  データをインポート
+                </Button>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".json"
+                  onChange={handleFileSelect}
+                  className="hidden"
+                />
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+      
+      {/* インポート確認ダイアログ */}
+      <Dialog open={importDialogOpen} onOpenChange={setImportDialogOpen}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>データのインポート</DialogTitle>
+            <DialogDescription>
+              選択したファイルからデータをインポートします
+            </DialogDescription>
+          </DialogHeader>
+          
+          <div className="space-y-4">
+            <div>
+              <p className="text-sm font-medium mb-2">インポートモード</p>
+              <div className="space-y-2">
+                <label className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    value="replace"
+                    checked={importMode === 'replace'}
+                    onChange={(e) => setImportMode(e.target.value as 'replace' | 'merge')}
+                  />
+                  <span>置き換え（既存のデータを全て削除して入れ替え）</span>
+                </label>
+                <label className="flex items-center space-x-2">
+                  <input
+                    type="radio"
+                    value="merge"
+                    checked={importMode === 'merge'}
+                    onChange={(e) => setImportMode(e.target.value as 'replace' | 'merge')}
+                  />
+                  <span>マージ（既存のデータに追加）</span>
+                </label>
+              </div>
+            </div>
+            
+            {importError && (
+              <Alert variant="destructive">
+                <AlertCircle className="h-4 w-4" />
+                <AlertDescription>{importError}</AlertDescription>
+              </Alert>
+            )}
+          </div>
+          
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setImportDialogOpen(false)}
+              disabled={importing}
+            >
+              キャンセル
+            </Button>
+            <Button onClick={handleImport} disabled={importing}>
+              {importing ? (
+                <>
+                  <Save className="h-4 w-4 mr-2 animate-spin" />
+                  インポート中...
+                </>
+              ) : (
+                'インポート実行'
+              )}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import { AppLayout } from '@/components/AppLayout';
 import { HomePage } from '@/pages/HomePage';
 import { CategoriesPage } from '@/pages/CategoriesPage';
+import { SettingsPage } from '@/pages/SettingsPage';
 
 export function AppRoutes() {
   return (
@@ -9,6 +10,7 @@ export function AppRoutes() {
       <Route element={<AppLayout />}>
         <Route path="/" element={<HomePage />} />
         <Route path="/categories" element={<CategoriesPage />} />
+        <Route path="/settings" element={<SettingsPage />} />
       </Route>
     </Routes>
   );

--- a/src/utils/export-import.test.ts
+++ b/src/utils/export-import.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { exportData, validateImportData, importData } from './export-import';
+import { db } from '@/db';
+import type { Task, Category, Setting } from '@/db';
+
+vi.mock('@/db', () => ({
+  db: {
+    tasks: {
+      toArray: vi.fn(),
+      clear: vi.fn(),
+      add: vi.fn(),
+    },
+    categories: {
+      toArray: vi.fn(),
+      clear: vi.fn(),
+      add: vi.fn(),
+    },
+    settings: {
+      toArray: vi.fn(),
+      clear: vi.fn(),
+      add: vi.fn(),
+      put: vi.fn(),
+      get: vi.fn(),
+    },
+    transaction: vi.fn((mode, ...tables) => {
+      const callback = tables[tables.length - 1];
+      return callback();
+    }),
+  },
+}));
+
+// crypto.randomUUID のモック
+Object.defineProperty(global, 'crypto', {
+  value: {
+    randomUUID: vi.fn(() => 'mocked-uuid'),
+  },
+});
+
+describe('export-import utilities', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe('exportData', () => {
+    it('should export all data in the correct format', async () => {
+      const mockTasks: Task[] = [
+        {
+          id: 'task-1',
+          title: 'Test Task',
+          status: 'pending',
+          createdAt: 123,
+          updatedAt: 456,
+        },
+      ];
+      
+      const mockCategories: Category[] = [
+        {
+          id: 'cat-1',
+          name: 'Work',
+          color: '#123456',
+          order: 1,
+        },
+      ];
+      
+      const mockSettings: Setting[] = [
+        { key: 'theme', value: 'dark' },
+      ];
+      
+      vi.mocked(db.tasks.toArray).mockResolvedValue(mockTasks);
+      vi.mocked(db.categories.toArray).mockResolvedValue(mockCategories);
+      vi.mocked(db.settings.toArray).mockResolvedValue(mockSettings);
+      
+      const result = await exportData();
+      
+      expect(result).toEqual({
+        version: '1.0.0',
+        exportedAt: expect.any(Number),
+        data: {
+          tasks: mockTasks,
+          categories: mockCategories,
+          settings: mockSettings,
+        },
+      });
+    });
+  });
+
+  describe('validateImportData', () => {
+    it('should validate correct export data', () => {
+      const validData = {
+        version: '1.0.0',
+        exportedAt: Date.now(),
+        data: {
+          tasks: [
+            {
+              id: 'task-1',
+              title: 'Test Task',
+              status: 'pending',
+              createdAt: 123,
+              updatedAt: 456,
+            },
+          ],
+          categories: [
+            {
+              id: 'cat-1',
+              name: 'Work',
+              color: '#123456',
+              order: 1,
+            },
+          ],
+          settings: [
+            { key: 'theme', value: 'dark' },
+          ],
+        },
+      };
+      
+      expect(validateImportData(validData)).toBe(true);
+    });
+
+    it('should reject invalid data', () => {
+      const invalidCases = [
+        null,
+        {},
+        { version: '1.0.0' }, // missing data
+        { version: '1.0.0', exportedAt: 123 }, // missing data
+        { version: '1.0.0', exportedAt: 123, data: {} }, // missing arrays
+        {
+          version: '1.0.0',
+          exportedAt: 123,
+          data: {
+            tasks: [{ title: 'Test' }], // missing required fields
+            categories: [],
+            settings: [],
+          },
+        },
+      ];
+      
+      invalidCases.forEach(data => {
+        expect(validateImportData(data)).toBe(false);
+      });
+    });
+  });
+
+  describe('importData', () => {
+    it('should import data in replace mode', async () => {
+      const importData = {
+        version: '1.0.0',
+        exportedAt: Date.now(),
+        data: {
+          tasks: [
+            {
+              id: 'task-1',
+              title: 'Test Task',
+              status: 'pending' as const,
+              createdAt: 123,
+              updatedAt: 456,
+            },
+          ],
+          categories: [
+            {
+              id: 'cat-1',
+              name: 'Work',
+              color: '#123456',
+              order: 1,
+            },
+          ],
+          settings: [
+            { key: 'theme', value: 'dark' },
+          ],
+        },
+      };
+      
+      const { importData: importFn } = await import('./export-import');
+      await importFn(importData, 'replace');
+      
+      // Clear operationsが呼ばれているか確認
+      expect(db.tasks.clear).toHaveBeenCalled();
+      expect(db.categories.clear).toHaveBeenCalled();
+      expect(db.settings.clear).toHaveBeenCalled();
+      
+      // データが追加されているか確認
+      expect(db.categories.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: 'Work',
+          color: '#123456',
+          order: 1,
+          id: 'mocked-uuid',
+        })
+      );
+      
+      expect(db.tasks.add).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Test Task',
+          status: 'pending',
+          id: 'mocked-uuid',
+        })
+      );
+      
+      expect(db.settings.put).toHaveBeenCalledWith({ key: 'theme', value: 'dark' });
+    });
+
+    it('should import data in merge mode', async () => {
+      vi.mocked(db.settings.get).mockResolvedValue(null);
+      
+      const importData = {
+        version: '1.0.0',
+        exportedAt: Date.now(),
+        data: {
+          tasks: [],
+          categories: [],
+          settings: [
+            { key: 'newSetting', value: 'newValue' },
+          ],
+        },
+      };
+      
+      const { importData: importFn } = await import('./export-import');
+      await importFn(importData, 'merge');
+      
+      // Clear operationsが呼ばれていないことを確認
+      expect(db.tasks.clear).not.toHaveBeenCalled();
+      expect(db.categories.clear).not.toHaveBeenCalled();
+      expect(db.settings.clear).not.toHaveBeenCalled();
+      
+      // 新しい設定のみ追加
+      expect(db.settings.add).toHaveBeenCalledWith({ key: 'newSetting', value: 'newValue' });
+    });
+
+    it('should throw error for invalid data', async () => {
+      const invalidData = { invalid: 'data' };
+      
+      const { importData: importFn } = await import('./export-import');
+      await expect(importFn(invalidData as any)).rejects.toThrow('無効なインポートデータです');
+    });
+  });
+});

--- a/src/utils/export-import.ts
+++ b/src/utils/export-import.ts
@@ -1,0 +1,159 @@
+import { db } from '@/db';
+import type { Task, Category, Setting } from '@/db';
+
+export interface ExportData {
+  version: string;
+  exportedAt: number;
+  data: {
+    tasks: Task[];
+    categories: Category[];
+    settings: Setting[];
+  };
+}
+
+/**
+ * 全データをエクスポート用のJSONオブジェクトとして取得
+ */
+export async function exportData(): Promise<ExportData> {
+  const tasks = await db.tasks.toArray();
+  const categories = await db.categories.toArray();
+  const settings = await db.settings.toArray();
+
+  return {
+    version: '1.0.0',
+    exportedAt: Date.now(),
+    data: {
+      tasks,
+      categories,
+      settings,
+    },
+  };
+}
+
+/**
+ * JSONデータをファイルとしてダウンロード
+ */
+export function downloadJSON(data: ExportData, filename?: string) {
+  const json = JSON.stringify(data, null, 2);
+  const blob = new Blob([json], { type: 'application/json' });
+  const url = URL.createObjectURL(blob);
+  
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename || `todo-claude-export-${new Date().toISOString().split('T')[0]}.json`;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  URL.revokeObjectURL(url);
+}
+
+/**
+ * ファイルを読み込んでJSONとしてパース
+ */
+export function readFile(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = (e) => resolve(e.target?.result as string);
+    reader.onerror = reject;
+    reader.readAsText(file);
+  });
+}
+
+/**
+ * インポートデータの検証
+ */
+export function validateImportData(data: unknown): data is ExportData {
+  if (!data || typeof data !== 'object') return false;
+  
+  const d = data as any;
+  
+  // 基本構造の確認
+  if (!d.version || !d.exportedAt || !d.data) return false;
+  if (typeof d.version !== 'string' || typeof d.exportedAt !== 'number') return false;
+  if (!d.data.tasks || !d.data.categories || !d.data.settings) return false;
+  if (!Array.isArray(d.data.tasks) || !Array.isArray(d.data.categories) || !Array.isArray(d.data.settings)) return false;
+  
+  // タスクの検証
+  for (const task of d.data.tasks) {
+    if (!task.title || typeof task.title !== 'string') return false;
+    if (!task.status || !['pending', 'done', 'archived'].includes(task.status)) return false;
+    if (!task.createdAt || typeof task.createdAt !== 'number') return false;
+    if (!task.updatedAt || typeof task.updatedAt !== 'number') return false;
+  }
+  
+  // カテゴリーの検証
+  for (const category of d.data.categories) {
+    if (!category.name || typeof category.name !== 'string') return false;
+    if (!category.color || typeof category.color !== 'string') return false;
+    if (typeof category.order !== 'number') return false;
+  }
+  
+  // 設定の検証
+  for (const setting of d.data.settings) {
+    if (!setting.key || typeof setting.key !== 'string') return false;
+  }
+  
+  return true;
+}
+
+/**
+ * データのインポート
+ * @param importMode - 'replace': 既存データを置き換え, 'merge': 既存データとマージ
+ */
+export async function importData(data: ExportData, importMode: 'replace' | 'merge' = 'replace') {
+  if (!validateImportData(data)) {
+    throw new Error('無効なインポートデータです');
+  }
+  
+  await db.transaction('rw', db.tasks, db.categories, db.settings, async () => {
+    if (importMode === 'replace') {
+      // 既存データを削除
+      await db.tasks.clear();
+      await db.categories.clear();
+      await db.settings.clear();
+    }
+    
+    // 新しいIDマッピング（重複を避けるため）
+    const idMapping = new Map<string, string>();
+    
+    // カテゴリーをインポート
+    for (const category of data.data.categories) {
+      const newId = crypto.randomUUID();
+      if (category.id) {
+        idMapping.set(category.id, newId);
+      }
+      
+      await db.categories.add({
+        ...category,
+        id: newId,
+      });
+    }
+    
+    // タスクをインポート
+    for (const task of data.data.tasks) {
+      const newId = crypto.randomUUID();
+      
+      // カテゴリーIDをマッピング
+      const categoryId = task.categoryId && idMapping.get(task.categoryId);
+      
+      await db.tasks.add({
+        ...task,
+        id: newId,
+        categoryId: categoryId || task.categoryId,
+      });
+    }
+    
+    // 設定をインポート
+    for (const setting of data.data.settings) {
+      if (importMode === 'merge') {
+        // マージモードでは既存の設定は上書きしない
+        const existing = await db.settings.get(setting.key);
+        if (!existing) {
+          await db.settings.add(setting);
+        }
+      } else {
+        await db.settings.put(setting);
+      }
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- JSON形式でタスク、カテゴリー、設定をエクスポート
- JSONファイルからデータをインポート（置き換え/マージのオプション付き）
- インポートデータのバリデーション機能

## Details
- 設定ページを作成し、通知設定とデータ管理セクションを追加
- export-importユーティリティを作成し、データのシリアライズ/デシリアライズを実装
- インポート時のIDマッピングで重複を回避
- shadcn/uiのAlertコンポーネントを追加

## Test plan
- [x] export-importユーティリティのユニットテストを追加
- [x] 設定ページのテストを追加
- [ ] エクスポート・インポートの動作確認
- [ ] 置き換えモードとマージモードの動作確認
- [ ] 不正なファイルのインポートエラーを確認

🤖 Generated with [Claude Code](https://claude.ai/code)