### PR TITLE
feat: All Tasksページを実装

### DIFF
--- a/src/pages/AllTasksPage.test.tsx
+++ b/src/pages/AllTasksPage.test.tsx
@@ -1,0 +1,278 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { BrowserRouter } from 'react-router-dom';
+import { AllTasksPage } from './AllTasksPage';
+import { useTasks } from '@/store/useTasks';
+import { useCategories } from '@/store/useCategories';
+import type { Task, Category } from '@/db';
+
+// Mock dependencies
+vi.mock('@/store/useTasks');
+vi.mock('@/store/useCategories');
+
+const mockTasks: Task[] = [
+  {
+    id: '1',
+    title: 'Pending Task',
+    status: 'pending',
+    createdAt: new Date('2023-01-01').getTime(),
+    updatedAt: new Date('2023-01-01').getTime(),
+    dueAt: new Date('2023-01-10').getTime(),
+    categoryId: 'cat-1',
+  },
+  {
+    id: '2',
+    title: 'Done Task',
+    status: 'done',
+    createdAt: new Date('2023-01-02').getTime(),
+    updatedAt: new Date('2023-01-02').getTime(),
+    categoryId: 'cat-2',
+  },
+  {
+    id: '3',
+    title: 'Archived Task',
+    status: 'archived',
+    createdAt: new Date('2023-01-03').getTime(),
+    updatedAt: new Date('2023-01-03').getTime(),
+  },
+];
+
+const mockCategories: Category[] = [
+  { id: 'cat-1', name: '仕事', color: '#1234567', order: 1 },
+  { id: 'cat-2', name: 'プライベート', color: '#7654321', order: 2 },
+];
+
+const mockUseTasks = {
+  tasks: mockTasks,
+  loading: false,
+  load: vi.fn(),
+  update: vi.fn(),
+  remove: vi.fn(),
+  toggleStatus: vi.fn(),
+};
+
+const mockUseCategories = {
+  categories: mockCategories,
+  load: vi.fn(),
+};
+
+const renderWithRouter = (component: React.ReactElement) => {
+  return render(component, { wrapper: BrowserRouter });
+};
+
+describe('AllTasksPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(useTasks).mockReturnValue(mockUseTasks as any);
+    vi.mocked(useCategories).mockReturnValue(mockUseCategories as any);
+  });
+
+  it('should render page and load data', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    expect(screen.getByText('全タスク')).toBeInTheDocument();
+    expect(screen.getByText('フィルター & 検索')).toBeInTheDocument();
+    expect(mockUseTasks.load).toHaveBeenCalled();
+    expect(mockUseCategories.load).toHaveBeenCalled();
+  });
+
+  it('should display all tasks by default', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    expect(screen.getByText('Pending Task')).toBeInTheDocument();
+    expect(screen.getByText('Done Task')).toBeInTheDocument();
+    expect(screen.getByText('Archived Task')).toBeInTheDocument();
+  });
+
+  it('should filter tasks by status', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    // ステータスセレクトボックスはラベルで特定
+    const statusLabel = screen.getByText('ステータス');
+    const statusSelect = statusLabel.nextElementSibling!;
+    fireEvent.click(statusSelect);
+    
+    const pendingOption = screen.getByRole('option', { name: '未完了' });
+    fireEvent.click(pendingOption);
+    
+    expect(screen.getByText('Pending Task')).toBeInTheDocument();
+    expect(screen.queryByText('Done Task')).not.toBeInTheDocument();
+    expect(screen.queryByText('Archived Task')).not.toBeInTheDocument();
+  });
+
+  it('should filter tasks by category', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    // カテゴリーセレクトボックスはラベルで特定
+    const categoryLabel = screen.getByText('カテゴリー');
+    const categorySelect = categoryLabel.nextElementSibling!;
+    fireEvent.click(categorySelect);
+    
+    const workOption = screen.getByRole('option', { name: '仕事' });
+    fireEvent.click(workOption);
+    
+    expect(screen.getByText('Pending Task')).toBeInTheDocument();
+    expect(screen.queryByText('Done Task')).not.toBeInTheDocument();
+  });
+
+  it('should search tasks by title', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    const searchInput = screen.getByPlaceholderText('タスクを検索...');
+    fireEvent.change(searchInput, { target: { value: 'Done' } });
+    
+    expect(screen.queryByText('Pending Task')).not.toBeInTheDocument();
+    expect(screen.getByText('Done Task')).toBeInTheDocument();
+    expect(screen.queryByText('Archived Task')).not.toBeInTheDocument();
+  });
+
+  it('should sort tasks', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    // ソートセレクトボックスはラベルで特定
+    const sortLabel = screen.getByText('並び順');
+    const sortSelect = sortLabel.nextElementSibling!;
+    fireEvent.click(sortSelect);
+    
+    const titleOption = screen.getByRole('option', { name: 'タイトル' });
+    fireEvent.click(titleOption);
+    
+    // タイトルによるソート時、デフォルトは降順なので逆順になる
+    const allTasks = Array.from(document.querySelectorAll('[id^="task-"]'));
+    expect(allTasks[0]).toHaveTextContent('Pending Task'); // P comes last in reverse
+    expect(allTasks[1]).toHaveTextContent('Done Task');    // D comes middle in reverse
+    expect(allTasks[2]).toHaveTextContent('Archived Task'); // A comes first in reverse
+  });
+
+  it('should toggle sort order', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    const sortButton = screen.getByText('降順');
+    fireEvent.click(sortButton);
+    
+    expect(screen.getByText('昇順')).toBeInTheDocument();
+    
+    // タスクカードの順序を確認（昇順=古い順）
+    const allTasks = Array.from(document.querySelectorAll('[id^="task-"]'));
+    expect(allTasks[0]).toHaveTextContent('Pending Task'); // 最も古い (2023-01-01)
+    expect(allTasks[1]).toHaveTextContent('Done Task'); // 中間 (2023-01-02)
+    expect(allTasks[2]).toHaveTextContent('Archived Task'); // 最も新しい (2023-01-03)
+  });
+
+  it('should select/deselect tasks', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    const checkboxes = screen.getAllByRole('checkbox');
+    
+    // 個別のタスクを選択
+    fireEvent.click(checkboxes[1]); // 最初のタスク
+    
+    expect(screen.getByText('1件選択中')).toBeInTheDocument();
+    
+    // 全選択
+    fireEvent.click(checkboxes[0]); // 全選択チェックボックス
+    
+    expect(screen.getByText('3件選択中')).toBeInTheDocument();
+  });
+
+  it('should archive selected tasks', async () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    // タスクを選択
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]); // 最初のタスクを選択
+    
+    const archiveButton = screen.getByText('アーカイブ');
+    fireEvent.click(archiveButton);
+    
+    await waitFor(() => {
+      expect(mockUseTasks.update).toHaveBeenCalled();
+      const calledArgs = mockUseTasks.update.mock.calls[0];
+      expect(calledArgs[1]).toEqual({ status: 'archived' });
+    });
+  });
+
+  it('should delete selected tasks with confirmation', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    
+    renderWithRouter(<AllTasksPage />);
+    
+    // タスクを選択
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+    
+    const deleteButton = screen.getByText('削除');
+    fireEvent.click(deleteButton);
+    
+    expect(confirmSpy).toHaveBeenCalledWith('1件のタスクを削除しますか？この操作は取り消せません。');
+    
+    await waitFor(() => {
+      expect(mockUseTasks.remove).toHaveBeenCalled();
+    });
+    
+    confirmSpy.mockRestore();
+  });
+
+  it('should cancel delete when confirmation is rejected', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    
+    renderWithRouter(<AllTasksPage />);
+    
+    // タスクを選択
+    const checkboxes = screen.getAllByRole('checkbox');
+    fireEvent.click(checkboxes[1]);
+    
+    const deleteButton = screen.getByText('削除');
+    fireEvent.click(deleteButton);
+    
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(mockUseTasks.remove).not.toHaveBeenCalled();
+    
+    confirmSpy.mockRestore();
+  });
+
+  it('should open task form when clicking on task', () => {
+    renderWithRouter(<AllTasksPage />);
+    
+    const task = screen.getByText('Pending Task');
+    fireEvent.click(task);
+    
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('should show loading state', () => {
+    vi.mocked(useTasks).mockReturnValue({
+      ...mockUseTasks,
+      loading: true,
+    } as any);
+    
+    renderWithRouter(<AllTasksPage />);
+    
+    expect(screen.getByText('読み込み中...')).toBeInTheDocument();
+  });
+
+  it('should show empty state with search', () => {
+    vi.mocked(useTasks).mockReturnValue({
+      ...mockUseTasks,
+      tasks: [],
+    } as any);
+    
+    renderWithRouter(<AllTasksPage />);
+    
+    const searchInput = screen.getByPlaceholderText('タスクを検索...');
+    fireEvent.change(searchInput, { target: { value: 'test' } });
+    
+    expect(screen.getByText('条件に一致するタスクがありません')).toBeInTheDocument();
+  });
+
+  it('should show empty state without search', () => {
+    vi.mocked(useTasks).mockReturnValue({
+      ...mockUseTasks,
+      tasks: [],
+    } as any);
+    
+    renderWithRouter(<AllTasksPage />);
+    
+    expect(screen.getByText('タスクがありません')).toBeInTheDocument();
+  });
+});

--- a/src/pages/AllTasksPage.tsx
+++ b/src/pages/AllTasksPage.tsx
@@ -1,0 +1,321 @@
+import { useEffect, useState } from 'react';
+import { Archive, CheckCircle, Circle, Filter, Search, SortAsc, Trash2 } from 'lucide-react';
+import { Navbar } from '@/components/Navbar';
+import { TaskCard } from '@/components/TaskCard';
+import { TaskForm } from '@/components/TaskForm';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { useTasks } from '@/store/useTasks';
+import { useCategories } from '@/store/useCategories';
+import type { Task } from '@/db';
+
+type FilterStatus = 'all' | 'pending' | 'done' | 'archived';
+type SortBy = 'createdAt' | 'dueAt' | 'title' | 'status';
+
+export function AllTasksPage() {
+  const { tasks, loading, load, update, remove, toggleStatus } = useTasks();
+  const { categories, load: loadCategories } = useCategories();
+  
+  const [searchQuery, setSearchQuery] = useState('');
+  const [filterStatus, setFilterStatus] = useState<FilterStatus>('all');
+  const [filterCategory, setFilterCategory] = useState<string>('all');
+  const [sortBy, setSortBy] = useState<SortBy>('createdAt');
+  const [sortAsc, setSortAsc] = useState(false);
+  const [selectedTasks, setSelectedTasks] = useState<Set<string>>(new Set());
+  const [editingTask, setEditingTask] = useState<Task | undefined>();
+  const [taskFormOpen, setTaskFormOpen] = useState(false);
+  
+  useEffect(() => {
+    load();
+    loadCategories();
+  }, [load, loadCategories]);
+  
+  // フィルタリングとソート
+  const filteredAndSortedTasks = tasks
+    .filter(task => {
+      // ステータスフィルター
+      if (filterStatus !== 'all' && task.status !== filterStatus) {
+        return false;
+      }
+      
+      // カテゴリーフィルター
+      if (filterCategory !== 'all' && task.categoryId !== filterCategory) {
+        return false;
+      }
+      
+      // 検索フィルター
+      if (searchQuery) {
+        const query = searchQuery.toLowerCase();
+        return (
+          task.title.toLowerCase().includes(query) ||
+          task.checklist?.some(item => item.text.toLowerCase().includes(query))
+        );
+      }
+      
+      return true;
+    })
+    .sort((a, b) => {
+      let compareValue = 0;
+      
+      switch (sortBy) {
+        case 'title':
+          compareValue = a.title.localeCompare(b.title);
+          break;
+        case 'dueAt':
+          compareValue = (a.dueAt || 0) - (b.dueAt || 0);
+          break;
+        case 'status':
+          compareValue = a.status.localeCompare(b.status);
+          break;
+        case 'createdAt':
+        default:
+          compareValue = a.createdAt - b.createdAt;
+          break;
+      }
+      
+      return sortAsc ? compareValue : -compareValue;
+    });
+  
+  // 全選択/全解除
+  const toggleSelectAll = () => {
+    if (selectedTasks.size === filteredAndSortedTasks.length && filteredAndSortedTasks.length > 0) {
+      setSelectedTasks(new Set());
+    } else {
+      setSelectedTasks(new Set(filteredAndSortedTasks.map(task => task.id!)));
+    }
+  };
+  
+  // タスクの選択切り替え
+  const toggleTaskSelection = (taskId: string) => {
+    const newSelected = new Set(selectedTasks);
+    if (newSelected.has(taskId)) {
+      newSelected.delete(taskId);
+    } else {
+      newSelected.add(taskId);
+    }
+    setSelectedTasks(newSelected);
+  };
+  
+  // 一括アーカイブ
+  const archiveSelected = async () => {
+    for (const taskId of selectedTasks) {
+      await update(taskId, { status: 'archived' });
+    }
+    setSelectedTasks(new Set());
+  };
+  
+  // 一括削除
+  const deleteSelected = async () => {
+    if (!confirm(`${selectedTasks.size}件のタスクを削除しますか？この操作は取り消せません。`)) {
+      return;
+    }
+    
+    for (const taskId of selectedTasks) {
+      await remove(taskId);
+    }
+    setSelectedTasks(new Set());
+  };
+  
+  const openTaskForm = (task?: Task) => {
+    setEditingTask(task);
+    setTaskFormOpen(true);
+  };
+  
+  const handleTaskSubmit = async (taskData: Partial<Task>) => {
+    if (editingTask?.id) {
+      await update(editingTask.id, taskData);
+    }
+  };
+  
+  if (loading) {
+    return <div className="flex h-screen items-center justify-center">読み込み中...</div>;
+  }
+  
+  return (
+    <div className="h-screen flex flex-col bg-background">
+      <Navbar />
+      
+      <div className="flex-1 overflow-y-auto">
+        <div className="container max-w-6xl mx-auto p-4">
+          <div className="mb-6">
+            <h1 className="text-2xl font-bold mb-4">全タスク</h1>
+            
+            {/* フィルター・検索部分 */}
+            <Card>
+              <CardHeader>
+                <CardTitle className="text-lg">フィルター & 検索</CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-4">
+                {/* 検索ボックス */}
+                <div className="relative">
+                  <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+                  <Input
+                    value={searchQuery}
+                    onChange={(e) => setSearchQuery(e.target.value)}
+                    placeholder="タスクを検索..."
+                    className="pl-10"
+                  />
+                </div>
+                
+                {/* フィルターとソート */}
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
+                  {/* ステータスフィルター */}
+                  <div>
+                    <label className="text-sm font-medium mb-1 block">ステータス</label>
+                    <Select value={filterStatus} onValueChange={(v) => setFilterStatus(v as FilterStatus)}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">すべて</SelectItem>
+                        <SelectItem value="pending">未完了</SelectItem>
+                        <SelectItem value="done">完了</SelectItem>
+                        <SelectItem value="archived">アーカイブ</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  
+                  {/* カテゴリーフィルター */}
+                  <div>
+                    <label className="text-sm font-medium mb-1 block">カテゴリー</label>
+                    <Select value={filterCategory} onValueChange={setFilterCategory}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="all">すべて</SelectItem>
+                        {categories.map(category => (
+                          <SelectItem key={category.id} value={category.id!}>
+                            {category.name}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  
+                  {/* ソート */}
+                  <div>
+                    <label className="text-sm font-medium mb-1 block">並び順</label>
+                    <Select value={sortBy} onValueChange={(v) => setSortBy(v as SortBy)}>
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectItem value="createdAt">作成日</SelectItem>
+                        <SelectItem value="dueAt">期限</SelectItem>
+                        <SelectItem value="title">タイトル</SelectItem>
+                        <SelectItem value="status">ステータス</SelectItem>
+                      </SelectContent>
+                    </Select>
+                  </div>
+                  
+                  {/* ソート順 */}
+                  <div className="flex items-end">
+                    <Button
+                      variant="outline"
+                      onClick={() => setSortAsc(!sortAsc)}
+                      className="w-full"
+                    >
+                      <SortAsc className={`h-4 w-4 mr-2 ${sortAsc ? '' : 'rotate-180'}`} />
+                      {sortAsc ? '昇順' : '降順'}
+                    </Button>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          </div>
+          
+          {/* 選択されたタスクの操作 */}
+          {selectedTasks.size > 0 && (
+            <div className="mb-4 p-4 bg-muted rounded-lg flex items-center justify-between">
+              <span className="text-sm font-medium">
+                {selectedTasks.size}件選択中
+              </span>
+              <div className="flex gap-2">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={archiveSelected}
+                >
+                  <Archive className="h-4 w-4 mr-1" />
+                  アーカイブ
+                </Button>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  onClick={deleteSelected}
+                >
+                  <Trash2 className="h-4 w-4 mr-1" />
+                  削除
+                </Button>
+              </div>
+            </div>
+          )}
+          
+          {/* タスク一覧 */}
+          <div className="space-y-3">
+            {/* 全選択チェックボックス */}
+            {filteredAndSortedTasks.length > 0 && (
+              <div className="flex items-center gap-3 p-4 border rounded-lg">
+                <Checkbox
+                  checked={selectedTasks.size === filteredAndSortedTasks.length && filteredAndSortedTasks.length > 0}
+                  onCheckedChange={toggleSelectAll}
+                />
+                <span className="text-sm font-medium">すべて選択</span>
+                <span className="text-sm text-muted-foreground">
+                  ({filteredAndSortedTasks.length}件のタスク)
+                </span>
+              </div>
+            )}
+            
+            {/* タスク一覧 */}
+            {filteredAndSortedTasks.map(task => (
+              <div key={task.id} className="flex items-center gap-3">
+                <Checkbox
+                  checked={selectedTasks.has(task.id!)}
+                  onCheckedChange={() => toggleTaskSelection(task.id!)}
+                />
+                <div className="flex-1">
+                  <TaskCard
+                    task={task}
+                    onToggle={toggleStatus}
+                    onClick={() => openTaskForm(task)}
+                  />
+                </div>
+              </div>
+            ))}
+            
+            {/* 空状態 */}
+            {filteredAndSortedTasks.length === 0 && (
+              <div className="text-center py-12">
+                <p className="text-muted-foreground">
+                  {searchQuery || filterStatus !== 'all' || filterCategory !== 'all'
+                    ? '条件に一致するタスクがありません'
+                    : 'タスクがありません'}
+                </p>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+      
+      {/* タスク編集フォーム */}
+      <TaskForm
+        open={taskFormOpen}
+        onOpenChange={setTaskFormOpen}
+        task={editingTask}
+        onSubmit={handleTaskSubmit}
+        onDelete={editingTask?.id ? () => remove(editingTask.id!) : undefined}
+      />
+    </div>
+  );
+}

--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import { AppLayout } from '@/components/AppLayout';
 import { HomePage } from '@/pages/HomePage';
 import { CategoriesPage } from '@/pages/CategoriesPage';
+import { AllTasksPage } from '@/pages/AllTasksPage';
 import { SettingsPage } from '@/pages/SettingsPage';
 
 export function AppRoutes() {
@@ -10,6 +11,7 @@ export function AppRoutes() {
       <Route element={<AppLayout />}>
         <Route path="/" element={<HomePage />} />
         <Route path="/categories" element={<CategoriesPage />} />
+        <Route path="/all" element={<AllTasksPage />} />
         <Route path="/settings" element={<SettingsPage />} />
       </Route>
     </Routes>

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -16,3 +16,10 @@ if (!global.crypto?.randomUUID) {
     }
   });
 }
+
+// Mock ResizeObserver for tests
+global.ResizeObserver = class ResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+};


### PR DESCRIPTION
## Summary
- 全タスクを一覧表示するページを追加
- 検索、フィルタリング、ソート機能を実装
- 複数タスクの選択と一括操作機能を追加

## Features
- ステータス（未完了/完了/アーカイブ）でのフィルタリング
- カテゴリーでのフィルタリング
- タスクタイトルでの検索
- 作成日、期限、タイトル、ステータスでのソート（昇降順切り替え可能）
- 複数タスクの選択と一括アーカイブ/削除

## Test plan
- [x] All Tasksページのテストを追加し、全て通過することを確認
- [ ] フィルタリング、検索、ソートの動作確認
- [ ] 一括操作の動作確認
- [ ] モバイルレスポンシブでの表示確認

🤖 Generated with [Claude Code](https://claude.ai/code)