### PR TITLE
fix: ビルドエラーを修正

### DIFF
--- a/src/pages/AllTasksPage.tsx
+++ b/src/pages/AllTasksPage.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Archive, CheckCircle, Circle, Filter, Search, SortAsc, Trash2 } from 'lucide-react';
+import { Archive, Search, SortAsc, Trash2 } from 'lucide-react';
 import { Navbar } from '@/components/Navbar';
 import { TaskCard } from '@/components/TaskCard';
 import { TaskForm } from '@/components/TaskForm';

--- a/src/pages/SettingsPage.test.tsx
+++ b/src/pages/SettingsPage.test.tsx
@@ -81,7 +81,6 @@ describe('SettingsPage', () => {
   it('should handle file selection and show import dialog', () => {
     renderWithRouter(<SettingsPage />);
     
-    const importButton = screen.getByText('データをインポート');
     const fileInput = document.querySelector('input[type="file"]') as HTMLInputElement;
     
     expect(fileInput).toBeInTheDocument();

--- a/src/store/useSettings.ts
+++ b/src/store/useSettings.ts
@@ -9,10 +9,12 @@ interface SettingsStore {
   snoozeMin: number;
   loading: boolean;
   error: string | null;
+  settings: Record<string, any>;
   load: () => Promise<void>;
   setTheme: (theme: Theme) => Promise<void>;
   setNotifyBeforeMin: (minutes: number) => Promise<void>;
   setSnoozeMin: (minutes: number) => Promise<void>;
+  updateSetting: (key: string, value: any) => Promise<void>;
 }
 
 export const useSettings = create<SettingsStore>((set) => ({
@@ -21,6 +23,7 @@ export const useSettings = create<SettingsStore>((set) => ({
   snoozeMin: 5,
   loading: false,
   error: null,
+  settings: {},
   
   load: async () => {
     set({ loading: true, error: null });
@@ -35,6 +38,7 @@ export const useSettings = create<SettingsStore>((set) => ({
         theme: (settingsMap.theme as Theme) || 'light',
         notifyBeforeMin: (settingsMap.notifyBeforeMin as number) || 15,
         snoozeMin: (settingsMap.snoozeMin as number) || 5,
+        settings: settingsMap,
         loading: false,
       });
     } catch (error) {
@@ -64,6 +68,20 @@ export const useSettings = create<SettingsStore>((set) => ({
     try {
       await db.settings.put({ key: 'snoozeMin', value: minutes });
       set({ snoozeMin: minutes });
+    } catch (error) {
+      set({ error: (error as Error).message });
+    }
+  },
+  
+  updateSetting: async (key, value) => {
+    try {
+      await db.settings.put({ key, value });
+      set((state) => ({
+        settings: { ...state.settings, [key]: value },
+        ...(key === 'theme' && { theme: value }),
+        ...(key === 'notifyBeforeMin' && { notifyBeforeMin: value }),
+        ...(key === 'snoozeMin' && { snoozeMin: value }),
+      }));
     } catch (error) {
       set({ error: (error as Error).message });
     }

--- a/src/store/useTasks.recurrence.test.ts
+++ b/src/store/useTasks.recurrence.test.ts
@@ -3,7 +3,6 @@ import { renderHook, act } from '@testing-library/react';
 import { useTasks } from './useTasks';
 import { db } from '../db';
 import type { Task } from '../db';
-import { RRule } from 'rrule';
 
 vi.mock('../db', () => ({
   db: {

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -18,8 +18,10 @@ if (!global.crypto?.randomUUID) {
 }
 
 // Mock ResizeObserver for tests
-global.ResizeObserver = class ResizeObserver {
+const mockResizeObserver = class ResizeObserver {
   observe() {}
   unobserve() {}
   disconnect() {}
-};
+} as unknown as typeof ResizeObserver;
+
+(globalThis as any).ResizeObserver = mockResizeObserver;

--- a/src/utils/export-import.test.ts
+++ b/src/utils/export-import.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { exportData, validateImportData, importData } from './export-import';
+import { exportData, validateImportData } from './export-import';
 import { db } from '@/db';
 import type { Task, Category, Setting } from '@/db';
 
@@ -22,7 +22,7 @@ vi.mock('@/db', () => ({
       put: vi.fn(),
       get: vi.fn(),
     },
-    transaction: vi.fn((mode, ...tables) => {
+    transaction: vi.fn((_mode, ...tables) => {
       const callback = tables[tables.length - 1];
       return callback();
     }),
@@ -142,7 +142,7 @@ describe('export-import utilities', () => {
 
   describe('importData', () => {
     it('should import data in replace mode', async () => {
-      const importData = {
+      const mockImportData = {
         version: '1.0.0',
         exportedAt: Date.now(),
         data: {
@@ -170,7 +170,7 @@ describe('export-import utilities', () => {
       };
       
       const { importData: importFn } = await import('./export-import');
-      await importFn(importData, 'replace');
+      await importFn(mockImportData, 'replace');
       
       // Clear operationsが呼ばれているか確認
       expect(db.tasks.clear).toHaveBeenCalled();


### PR DESCRIPTION
## Summary

- TypeScriptコンパイラエラーを修正
- 未使用のインポートと変数を整理
- SettingsPageで必要なupdateSettingメソッドを実装

## 修正内容

1. : updateSettingメソッドを追加、未使用変数を削除
2. : 未使用インポートを削除
3. : 未使用変数を削除
4. : ResizeObserverの型定義を修正
5. : 未使用インポートを削除
6. : 未使用インポートを削除

## テスト計画

- [x] 
> todo-claude@0.0.0 build
> tsc && vite build

vite v5.4.19 building for production...
transforming...
✓ 1785 modules transformed.
rendering chunks...
computing gzip size...
dist/manifest.webmanifest                          0.41 kB
dist/index.html                                    0.67 kB │ gzip:   0.38 kB
dist/assets/index-DuZd0nbg.css                    27.28 kB │ gzip:   5.66 kB
dist/assets/workbox-window.prod.es5-B9K5rw8f.js    5.72 kB │ gzip:   2.35 kB
dist/assets/index-Cluu_phM.js                    480.47 kB │ gzip: 155.68 kB
✓ built in 1.50s

PWA v0.20.5
Building src/sw/sw.ts service worker ("es" format)...
vite v5.4.19 building for production...
transforming...
✓ 77 modules transformed.
rendering chunks...
computing gzip size...
dist/sw.mjs  25.96 kB │ gzip: 8.59 kB
✓ built in 446ms

PWA v0.20.5
mode      injectManifest
format:   es
precache  8 entries (504.82 KiB)
files generated
  dist/sw.jsが正常に完了
- [x] TypeScriptのすべての型エラーが解消

🤖 Generated with [Claude Code](https://claude.ai/code)